### PR TITLE
size optimized and no enforced volume

### DIFF
--- a/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.ee
+++ b/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.ee
@@ -5,7 +5,7 @@
 # ORACLE DOCKERFILES PROJECT
 # --------------------------
 # This is the Dockerfile for Oracle Database 12c Release 1 Enterprise Edition
-# 
+#
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # (1) linuxamd64_12102_database_1of2.zip
@@ -16,8 +16,8 @@
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Put all downloaded files in the same directory as this Dockerfile
-# Run: 
-#      $ docker build -t oracle/database:12.1.0.2-ee . 
+# Run:
+#      $ docker build -t oracle/database:12.1.0.2-ee .
 #
 # Pull base image
 # ---------------
@@ -27,12 +27,15 @@ FROM oraclelinux:7-slim
 # ----------
 MAINTAINER Gerald Venzl <gerald.venzl@oracle.com>
 
+LABEL oracle.version="12.1.0.2-ee"
+
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------
 ENV ORACLE_BASE=/opt/oracle \
     ORACLE_HOME=/opt/oracle/product/12.1.0.2/dbhome_1 \
     INSTALL_FILE_1="linuxamd64_12102_database_1of2.zip" \
     INSTALL_FILE_2="linuxamd64_12102_database_2of2.zip" \
+    INSTALL_FILE_BASE_URL="https://example.com/repository/database-installers" \
     INSTALL_RSP="db_inst.rsp" \
     CONFIG_RSP="dbca.rsp.tmpl" \
     PWD_FILE="setPassword.sh" \
@@ -52,7 +55,7 @@ ENV INSTALL_DIR=$ORACLE_BASE/install \
 
 # Copy binaries
 # -------------
-COPY $INSTALL_FILE_1 $INSTALL_FILE_2 $INSTALL_RSP $PERL_INSTALL_FILE $SETUP_LINUX_FILE $CHECK_SPACE_FILE $INSTALL_DB_BINARIES_FILE $INSTALL_DIR/
+COPY $INSTALL_RSP $PERL_INSTALL_FILE $SETUP_LINUX_FILE $CHECK_SPACE_FILE $INSTALL_DB_BINARIES_FILE $INSTALL_DIR/
 COPY $RUN_FILE $START_FILE $CREATE_DB_FILE $CONFIG_RSP $PWD_FILE $ORACLE_BASE/
 
 RUN chmod ug+x $INSTALL_DIR/*.sh && \
@@ -60,9 +63,12 @@ RUN chmod ug+x $INSTALL_DIR/*.sh && \
     $INSTALL_DIR/$CHECK_SPACE_FILE && \
     $INSTALL_DIR/$SETUP_LINUX_FILE
 
-# Install DB software binaries
+# Install DB software binaries (download, unzip and remove big files is done in same RUN block in order to minimize image size)
 USER oracle
-RUN $INSTALL_DIR/$INSTALL_DB_BINARIES_FILE EE
+RUN cd $INSTALL_DIR \
+    && wget --no-verbose $INSTALL_FILE_BASE_URL/$INSTALL_FILE_1 \
+    && wget --no-verbose $INSTALL_FILE_BASE_URL/$INSTALL_FILE_2 \
+    && $INSTALL_DIR/$INSTALL_DB_BINARIES_FILE EE
 
 USER root
 RUN $ORACLE_BASE/oraInventory/orainstRoot.sh && \
@@ -74,6 +80,6 @@ WORKDIR /home/oracle
 
 VOLUME ["$ORACLE_BASE/oradata"]
 EXPOSE 1521 5500
-    
-# Define default command to start Oracle Database. 
+
+# Define default command to start Oracle Database.
 CMD $ORACLE_BASE/$RUN_FILE

--- a/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.ee
+++ b/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.ee
@@ -78,7 +78,6 @@ RUN $ORACLE_BASE/oraInventory/orainstRoot.sh && \
 USER oracle
 WORKDIR /home/oracle
 
-VOLUME ["$ORACLE_BASE/oradata"]
 EXPOSE 1521 5500
 
 # Define default command to start Oracle Database.

--- a/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.se2
+++ b/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.se2
@@ -5,7 +5,7 @@
 # ORACLE DOCKERFILES PROJECT
 # --------------------------
 # This is the Dockerfile for Oracle Database 12c Release 1 Standard Edition 2
-# 
+#
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # (1) linuxamd64_12102_database_se2_1of2.zip
@@ -16,8 +16,8 @@
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Put all downloaded files in the same directory as this Dockerfile
-# Run: 
-#      $ docker build -t oracle/database:12.1.0.2-se2 . 
+# Run:
+#      $ docker build -t oracle/database:12.1.0.2-se2 .
 #
 # Pull base image
 # ---------------
@@ -27,12 +27,15 @@ FROM oraclelinux:7-slim
 # ----------
 MAINTAINER Gerald Venzl <gerald.venzl@oracle.com>
 
+LABEL oracle.version="12.1.0.2-se2"
+
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------
 ENV ORACLE_BASE=/opt/oracle \
     ORACLE_HOME=/opt/oracle/product/12.1.0.2/dbhome_1 \
     INSTALL_FILE_1="linuxamd64_12102_database_se2_1of2.zip" \
     INSTALL_FILE_2="linuxamd64_12102_database_se2_2of2.zip" \
+    INSTALL_FILE_BASE_URL="https://example.com/repository/database-installers" \
     INSTALL_RSP="db_inst.rsp" \
     CONFIG_RSP="dbca.rsp.tmpl" \
     PWD_FILE="setPassword.sh" \
@@ -52,7 +55,7 @@ ENV INSTALL_DIR=$ORACLE_BASE/install \
 
 # Copy binaries
 # -------------
-COPY $INSTALL_FILE_1 $INSTALL_FILE_2 $INSTALL_RSP $PERL_INSTALL_FILE $SETUP_LINUX_FILE $CHECK_SPACE_FILE $INSTALL_DB_BINARIES_FILE $INSTALL_DIR/
+COPY $INSTALL_RSP $PERL_INSTALL_FILE $SETUP_LINUX_FILE $CHECK_SPACE_FILE $INSTALL_DB_BINARIES_FILE $INSTALL_DIR/
 COPY $RUN_FILE $START_FILE $CREATE_DB_FILE $CONFIG_RSP $PWD_FILE $ORACLE_BASE/
 
 RUN chmod ug+x $INSTALL_DIR/*.sh && \
@@ -60,9 +63,12 @@ RUN chmod ug+x $INSTALL_DIR/*.sh && \
     $INSTALL_DIR/$CHECK_SPACE_FILE && \
     $INSTALL_DIR/$SETUP_LINUX_FILE
 
-# Install DB software binaries
+# Install DB software binaries (download, unzip and remove big files is done in same RUN block in order to minimize image size)
 USER oracle
-RUN $INSTALL_DIR/$INSTALL_DB_BINARIES_FILE SE2
+RUN cd $INSTALL_DIR \
+    && wget --no-verbose $INSTALL_FILE_BASE_URL/$INSTALL_FILE_1 \
+    && wget --no-verbose $INSTALL_FILE_BASE_URL/$INSTALL_FILE_2 \
+    && $INSTALL_DIR/$INSTALL_DB_BINARIES_FILE SE2
 
 USER root
 RUN $ORACLE_BASE/oraInventory/orainstRoot.sh && \
@@ -74,6 +80,6 @@ WORKDIR /home/oracle
 
 VOLUME ["$ORACLE_BASE/oradata"]
 EXPOSE 1521 5500
-    
-# Define default command to start Oracle Database. 
+
+# Define default command to start Oracle Database.
 CMD $ORACLE_BASE/$RUN_FILE

--- a/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.se2
+++ b/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.se2
@@ -78,7 +78,6 @@ RUN $ORACLE_BASE/oraInventory/orainstRoot.sh && \
 USER oracle
 WORKDIR /home/oracle
 
-VOLUME ["$ORACLE_BASE/oradata"]
 EXPOSE 1521 5500
 
 # Define default command to start Oracle Database.

--- a/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
@@ -2,13 +2,13 @@
 # LICENSE CDDL 1.0 + GPL 2.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.
-# 
+#
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com
 # Description: Runs the Oracle Database inside the container
-# 
+#
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-# 
+#
 
 ########### Move DB files ############
 function moveFiles {
@@ -23,7 +23,7 @@ function moveFiles {
 
    # oracle user does not have permissions in /etc, hence cp and not mv
    cp /etc/oratab $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
-   
+
    symLinkFiles;
 }
 
@@ -33,16 +33,16 @@ function symLinkFiles {
    if [ ! -L $ORACLE_HOME/dbs/spfile$ORACLE_SID.ora ]; then
       ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/spfile$ORACLE_SID.ora $ORACLE_HOME/dbs/spfile$ORACLE_SID.ora
    fi;
-   
+
    if [ ! -L $ORACLE_HOME/dbs/orapw$ORACLE_SID ]; then
       ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/orapw$ORACLE_SID $ORACLE_HOME/dbs/orapw$ORACLE_SID
    fi;
-   
+
    if [ ! -L $ORACLE_HOME/network/admin/tnsnames.ora ]; then
       ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/tnsnames.ora $ORACLE_HOME/network/admin/tnsnames.ora
    fi;
 
-   # oracle user does not have permissions in /etc, hence cp and not ln 
+   # oracle user does not have permissions in /etc, hence cp and not ln
    cp $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/oratab /etc/oratab
 
 }
@@ -84,7 +84,7 @@ EOF
 
 # Check whether container has enough memory
 # Github issue #219: Prevent integer overflow,
-# only check if memory digits are less than 11 (single GB range and below) 
+# only check if memory digits are less than 11 (single GB range and below)
 if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes | wc -c` -lt 11 ]; then
    if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes` -lt 2147483648 ]; then
       echo "Error: The container doesn't have enough memory allocated."
@@ -113,7 +113,7 @@ else
      echo "Error: The ORACLE_SID must only be up to 12 characters long."
      exit 1;
   fi;
-  
+
   # Check whether SID is alphanumeric
   # Github issue #246: Cannot start OracleDB image
   if [[ "$ORACLE_SID" =~ [^a-zA-Z0-9] ]]; then
@@ -135,24 +135,24 @@ fi;
 # Check whether database already exists
 if [ -d $ORACLE_BASE/oradata/$ORACLE_SID ]; then
    symLinkFiles;
-   
+
    # Make sure audit file destination exists
    if [ ! -d $ORACLE_BASE/admin/$ORACLE_SID/adump ]; then
       mkdir -p $ORACLE_BASE/admin/$ORACLE_SID/adump
    fi;
-   
+
    # Start database
    $ORACLE_BASE/$START_FILE;
-   
+
 else
    # Remove database config files, if they exist
    rm -f $ORACLE_HOME/dbs/spfile$ORACLE_SID.ora
    rm -f $ORACLE_HOME/dbs/orapw$ORACLE_SID
    rm -f $ORACLE_HOME/network/admin/tnsnames.ora
-   
+
    # Create database
    $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB;
-   
+
    # Move database operational files to oradata
    moveFiles;
 fi;
@@ -161,6 +161,10 @@ echo "#########################"
 echo "DATABASE IS READY TO USE!"
 echo "#########################"
 
-tail -f $ORACLE_BASE/diag/rdbms/*/*/trace/alert*.log &
-childPID=$!
-wait $childPID
+if [ "$1" == "no-wait" ]; then
+    exit
+else
+    tail -f $ORACLE_BASE/diag/rdbms/*/*/trace/alert*.log &
+    childPID=$!
+    wait $childPID
+fi;

--- a/OracleDatabase/dockerfiles/12.1.0.2/setPassword.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/setPassword.sh
@@ -2,17 +2,16 @@
 # LICENSE CDDL 1.0 + GPL 2.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.
-# 
+#
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com
 # Description: Sets the password for sys, system and pdb_admin
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-# 
+#
 
 ORACLE_PWD=$1
 ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
 ORAENV_ASK=NO
 source oraenv
 

--- a/OracleDatabase/dockerfiles/README.txt
+++ b/OracleDatabase/dockerfiles/README.txt
@@ -1,1 +1,5 @@
-For 12.1.0.2, adjust the INSTALL_FILE_BASE_URL in the corresponding Dockerfile first.
+For 12.1.0.2:
+- Before building this image, adjust the INSTALL_FILE_BASE_URL in the corresponding Dockerfile
+- When running the built image, don't forget to add a volume mapping for /opt/oracle/oradata if you want to keep your data!
+    Example:
+    docker run --name oracle -p 1521:1521 -p 5500:5500 -e ORACLE_SID=MYSID -v /opt/oracle/oradata:/opt/oracle/oradata oracle-nopdb-novolume:12.1.0.2-se2

--- a/OracleDatabase/dockerfiles/README.txt
+++ b/OracleDatabase/dockerfiles/README.txt
@@ -1,0 +1,1 @@
+For 12.1.0.2, adjust the INSTALL_FILE_BASE_URL in the corresponding Dockerfile first.

--- a/OracleDatabase/dockerfiles/buildDockerImage.sh
+++ b/OracleDatabase/dockerfiles/buildDockerImage.sh
@@ -107,7 +107,7 @@ else
 fi
 
 # Oracle Database Image Name
-IMAGE_NAME="oracle-nopdb:$VERSION-$EDITION"
+IMAGE_NAME="oracle-nopdb-novolume:$VERSION-$EDITION"
 
 # Go into version folder
 cd $VERSION

--- a/OracleDatabase/dockerfiles/buildDockerImage.sh
+++ b/OracleDatabase/dockerfiles/buildDockerImage.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
-# 
+#
 # Since: April, 2016
 # Author: gerald.venzl@oracle.com
 # Description: Build script for building Oracle Database Docker images.
-# 
+#
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-# 
+#
 # Copyright (c) 2014-2016 Oracle and/or its affiliates. All rights reserved.
-# 
+#
 
 usage() {
   cat << EOF
 
 Usage: buildDockerImage.sh -v [version] [-e | -s | -x] [-i]
 Builds a Docker Image for Oracle Database.
-  
+
 Parameters:
    -v: version to build
        Choose one of: $(for i in $(ls -d */); do echo -n "${i%%/}  "; done)
@@ -61,7 +61,7 @@ ENTERPRISE=0
 STANDARD=0
 EXPRESS=0
 VERSION="12.1.0.2"
-SKIPMD5=0
+SKIPMD5=1
 DOCKEROPS=""
 
 while getopts "hesxiv:" optname; do
@@ -107,7 +107,7 @@ else
 fi
 
 # Oracle Database Image Name
-IMAGE_NAME="oracle/database:$VERSION-$EDITION"
+IMAGE_NAME="oracle-nopdb:$VERSION-$EDITION"
 
 # Go into version folder
 cd $VERSION
@@ -162,12 +162,12 @@ echo ""
 
 if [ $? -eq 0 ]; then
 cat << EOF
-  Oracle Database Docker Image for '$EDITION' version $VERSION is ready to be extended: 
-    
+  Oracle Database Docker Image for '$EDITION' version $VERSION is ready to be extended:
+
     --> $IMAGE_NAME
 
   Build completed in $BUILD_ELAPSED seconds.
-  
+
 EOF
 
 else


### PR DESCRIPTION
Various improvements:
* optimize image size by getting binaries in a RUN block instead of COPY
* add LABEL oracle.version
* remove VOLUME for $ORACLE_BASE/oradata (for use with disposable databases)
* adjust image name (no PDB, no volume)
* allow running runOracle.sh without wait at the end (for use within other Dockerfiles)
